### PR TITLE
Debug rag lambda

### DIFF
--- a/RAG-lambda/chatbot_functions.py
+++ b/RAG-lambda/chatbot_functions.py
@@ -11,10 +11,18 @@ load_dotenv()
 
 def answer_application_question(conn, application_id: str, user_question: str, application_text: str = None, application_page_url: str = None, history: list[dict] = None) -> str:
     """Answers a user's question about a planning application."""
+
+    logging.info(
+        f"Answering application question for application_id={application_id} with user_question='{user_question}' and history={history}")
     # Get application text and page URL
     if application_text is None:
+        logging.info(
+            f"Fetching application text for application_id={application_id}")
         application_text = get_related_documents_text(conn, application_id)
+
     if application_page_url is None:
+        logging.info(
+            f"Fetching application page URL for application_id={application_id}")
         application_page_url = get_document_page_url(conn, application_id)
 
     # Generate OpenAI client

--- a/RAG-lambda/extract_document_data.py
+++ b/RAG-lambda/extract_document_data.py
@@ -323,6 +323,35 @@ def parse_pdf_links_from_html(html_content: str, page_url: str) -> list[dict[str
     return pdf_documents
 
 
+def filter_relevant_documents(documents: list[dict[str, str]]) -> list[dict[str, str]]:
+    """Filters the list of documents to include only those relevant for RAG indexing.
+
+    This is based on the document type, which is expected to be in the 'document_type' key.
+
+    Args:
+        documents: List of dicts with 'pdf_url' and 'document_type' keys.
+
+    Returns:
+        A filtered list of dicts containing only relevant documents.
+    """
+    relevant_types = {'application form',
+                      'design and access statement',
+                      'planning statement',
+                      'consultation summary',
+                      'environmental report',
+                      'application form - without personal data',
+                      'correspondence',
+                      'planning statement',
+                      'site notice'}
+
+    filtered_docs = [
+        doc for doc in documents
+        if doc['document_type'].lower().strip() in relevant_types
+    ]
+
+    return filtered_docs
+
+
 def get_pdf_links_from_page(session: requests.Session, url: str) -> list[dict[str, str]]:
     """Fetches an application's documents page and extracts all PDF links.
 
@@ -343,7 +372,16 @@ def get_pdf_links_from_page(session: requests.Session, url: str) -> list[dict[st
         logger.error("Server error on documents page: %s", url)
         return []
 
-    return parse_pdf_links_from_html(html_content, url)
+    documents = parse_pdf_links_from_html(html_content, url)
+
+    logger.info("Extracted %d documents before filtering", len(documents))
+
+    relevant_documents = filter_relevant_documents(documents)
+
+    logger.info("Filtered down to %d relevant documents for RAG",
+                len(relevant_documents))
+
+    return relevant_documents
 
 
 # -----------------------------------------------------
@@ -546,7 +584,7 @@ if __name__ == "__main__":
     print(f"Document URL for {application_number}: {document_url}")
 
     document_text_for_application = get_related_documents_text(conn,
-        application_number)
+                                                               application_number)
     for doc in document_text_for_application:
         print(f"Document Type: {doc['document_type']}")
         print(f"Document Text: {doc['document_text'][:500]}...")

--- a/RAG-lambda/lambda_function.py
+++ b/RAG-lambda/lambda_function.py
@@ -27,6 +27,7 @@ load_dotenv()
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
+
 def _get_credentials() -> dict:
     """Return DB credentials, preferring Secrets Manager over .env.
 
@@ -63,7 +64,7 @@ def _get_credentials() -> dict:
 def get_connection():
     """Return a new connection to the Postgres database."""
     creds = _get_credentials()
-    #ssl_cert = os.getenv("DB_SSL_CERT", "./global-bundle.pem")
+    # ssl_cert = os.getenv("DB_SSL_CERT", "./global-bundle.pem")
     logging.info(
         "Using DB credentials for user='%s', dbname='%s', host='%s', port='%s'.",
         creds.get("user"),
@@ -101,9 +102,10 @@ def get_connection():
         logger.error(f"Database connection failed: {e}")
         raise
 
+
 def lambda_handler(event, context):
     """Handle chatbot requests from the dashboard.
-    
+
     Expected request body:
     {
         "question_type": "application" | "appeal" | "general",
@@ -132,22 +134,28 @@ def lambda_handler(event, context):
 
         if question_type in ['application', 'appeal'] and not application_id:
             return {
-                    "statusCode": 400,
-                    "body": json.dumps(
-                        {"error": "application_id is required for this question"}
-                    ),
-                }
+                "statusCode": 400,
+                "body": json.dumps(
+                    {"error": "application_id is required for this question"}
+                ),
+            }
 
         if question_type == "application":
+            logger.info(
+                f"Processing application question for application_id={application_id}")
+
             response_text, history = answer_application_question(
                 conn, application_id, user_question, history=history
             )
+            logger.info(
+                f"Completed processing application question for application_id={application_id}")
         elif question_type == "appeal":
             response_text, history = answer_appeal_question(
                 conn, application_id, user_question, history=history
             )
         else:  # general
-            response_text, history = answer_general_question(user_question, history=history)
+            response_text, history = answer_general_question(
+                user_question, history=history)
 
         return {
             "statusCode": 200,
@@ -159,7 +167,8 @@ def lambda_handler(event, context):
         }
 
     except Exception as e:
-        logger.error(f"Error processing chatbot request: {str(e)}", exc_info=True)
+        logger.error(
+            f"Error processing chatbot request: {str(e)}", exc_info=True)
         return {
             "statusCode": 500,
             "body": json.dumps({"error": f"Internal server error: {str(e)}"}),

--- a/RAG-lambda/lambda_function.py
+++ b/RAG-lambda/lambda_function.py
@@ -1,13 +1,16 @@
 """Lambda function for handling chatbot requests from the dashboard.
 
-Receives question type, user question, and conversation history,
-then routes to the appropriate chatbot function.
+Routing modes:
+  1. POST /ask (API Gateway)      → dispatcher: create a job, invoke self async, return job_id
+  2. GET /status/{job_id} (API GW)→ status:     read job record from DynamoDB, return result
+  3. Direct async invocation      → worker:     run the RAG pipeline, write result to DynamoDB
 """
 
 import json
 import logging
-from dotenv import load_dotenv
 import os
+import time
+import uuid
 
 from dotenv import load_dotenv
 import psycopg2
@@ -22,11 +25,21 @@ from chatbot_functions import (
 SECRET_NAME = "c22-planning-pipeline-db-credentials"
 AWS_REGION = "eu-west-2"
 
+# DynamoDB table for async job results (set via env var from Terraform)
+DYNAMODB_TABLE = os.getenv("DYNAMODB_TABLE", "c22-planning-rag-jobs")
+
+# How long (seconds) a job record persists in DynamoDB before TTL expiry
+JOB_TTL_SECONDS = 3600
+
 load_dotenv()
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
+
+# ==========================================
+# DATABASE HELPERS (unchanged)
+# ==========================================
 
 def _get_credentials() -> dict:
     """Return DB credentials, preferring Secrets Manager over .env.
@@ -64,7 +77,6 @@ def _get_credentials() -> dict:
 def get_connection():
     """Return a new connection to the Postgres database."""
     creds = _get_credentials()
-    # ssl_cert = os.getenv("DB_SSL_CERT", "./global-bundle.pem")
     logging.info(
         "Using DB credentials for user='%s', dbname='%s', host='%s', port='%s'.",
         creds.get("user"),
@@ -73,10 +85,9 @@ def get_connection():
         creds.get("port"),
     )
 
-    # Validate credentials before attempting connection
     required_fields = ["host", "port", "dbname", "user", "password"]
-    missing_fields = [field for field in required_fields
-                      if not creds.get(field)]
+    missing_fields = [
+        field for field in required_fields if not creds.get(field)]
 
     if missing_fields:
         error_msg = (
@@ -103,73 +114,234 @@ def get_connection():
         raise
 
 
-def lambda_handler(event, context):
-    """Handle chatbot requests from the dashboard.
+# ==========================================
+# DYNAMODB HELPERS
+# ==========================================
 
-    Expected request body:
-    {
-        "question_type": "application" | "appeal" | "general",
-        "user_question": "The user's question",
-        "application_id": "app_id" (required for application/appeal),
-        "history": [{"role": "user"|"assistant", "content": "..."}, ...]
-    }
+def _store_job(job_id: str, status: str, **kwargs) -> None:
+    """Write or overwrite a job record in DynamoDB.
+
+    Args:
+        job_id: Unique job identifier
+        status: "pending" | "complete" | "error"
+        **kwargs: Extra fields to include (response, history, error, etc.)
     """
+    dynamodb = boto3.resource("dynamodb", region_name=AWS_REGION)
+    table = dynamodb.Table(DYNAMODB_TABLE)
+    item = {
+        "job_id": job_id,
+        "status": status,
+        # TTL lets DynamoDB auto-delete stale records after 1 hour
+        "ttl": int(time.time()) + JOB_TTL_SECONDS,
+        **kwargs,
+    }
+    table.put_item(Item=item)
+
+
+def _get_job(job_id: str) -> dict:
+    """Fetch a job record from DynamoDB.
+
+    Args:
+        job_id: Unique job identifier
+
+    Returns:
+        The job item dict, or an empty dict if not found
+    """
+    dynamodb = boto3.resource("dynamodb", region_name=AWS_REGION)
+    table = dynamodb.Table(DYNAMODB_TABLE)
+    response = table.get_item(Key={"job_id": job_id})
+    return response.get("Item", {})
+
+
+# ==========================================
+# MODE 1: DISPATCHER  (POST /ask)
+# ==========================================
+
+def _handle_dispatch(body: dict, context) -> dict:
+    """Create a job record, invoke self asynchronously, and return the job_id.
+
+    The dashboard receives a 202 immediately and polls /status/{job_id}
+    rather than waiting for a synchronous response through API Gateway
+    (which has a hard 29-second timeout, shorter than typical RAG jobs).
+
+    Args:
+        body: Parsed request body from the dashboard
+        context: Lambda context (used to get the current function name)
+
+    Returns:
+        API Gateway response with 202 status and job_id
+    """
+    question_type = body.get("question_type", "general")
+    user_question = body.get("user_question", "")
+    application_id = body.get("application_id")
+
+    # Validate required fields up-front so the user gets immediate feedback
+    if not user_question:
+        return {
+            "statusCode": 400,
+            "body": json.dumps({"error": "user_question is required"}),
+        }
+
+    if question_type in ["application", "appeal"] and not application_id:
+        return {
+            "statusCode": 400,
+            "body": json.dumps(
+                {"error": "application_id is required for this question type"}
+            ),
+        }
+
+    job_id = str(uuid.uuid4())
+
+    # Mark the job as pending before firing the async worker
+    _store_job(job_id, "pending")
+    logger.info(f"Created job {job_id} for question_type={question_type}")
+
+    # Payload passed to the async worker invocation
+    worker_payload = {
+        "job_id": job_id,
+        "question_type": question_type,
+        "user_question": user_question,
+        "application_id": application_id,
+        "history": body.get("history", []),
+    }
+
+    # Invoke this same Lambda asynchronously — it will route to _process_rag_job
+    lambda_client = boto3.client("lambda", region_name=AWS_REGION)
+    lambda_client.invoke(
+        FunctionName=context.function_name,
+        InvocationType="Event",  # async: returns immediately with status 202
+        Payload=json.dumps(worker_payload).encode(),
+    )
+    logger.info(f"Async worker invoked for job {job_id}")
+
+    return {
+        "statusCode": 202,
+        "body": json.dumps({"job_id": job_id, "status": "pending"}),
+    }
+
+
+# ==========================================
+# MODE 2: STATUS  (GET /status/{job_id})
+# ==========================================
+
+def _handle_status(event: dict) -> dict:
+    """Return the current status of a job from DynamoDB.
+
+    Args:
+        event: API Gateway event containing pathParameters
+
+    Returns:
+        API Gateway response with job status and result if complete
+    """
+    job_id = (event.get("pathParameters") or {}).get("job_id")
+
+    if not job_id:
+        return {
+            "statusCode": 400,
+            "body": json.dumps({"error": "job_id path parameter is required"}),
+        }
+
+    job = _get_job(job_id)
+
+    if not job:
+        return {
+            "statusCode": 404,
+            "body": json.dumps({"error": f"Job {job_id} not found"}),
+        }
+
+    return {
+        "statusCode": 200,
+        "body": json.dumps({
+            "job_id": job_id,
+            "status": job.get("status"),
+            "response": job.get("response"),
+            "history": job.get("history"),
+            "question_type": job.get("question_type"),
+            "error": job.get("error"),
+        }),
+    }
+
+
+# ==========================================
+# MODE 3: WORKER  (async self-invocation)
+# ==========================================
+
+def _process_rag_job(event: dict) -> None:
+    """Run the RAG pipeline and write the result to DynamoDB.
+
+    Called when this Lambda is invoked asynchronously by _handle_dispatch.
+    There is no API Gateway in this path, so the return value is unused;
+    the result is communicated via the DynamoDB job record.
+
+    Args:
+        event: The worker payload built by _handle_dispatch
+    """
+    job_id = event.get("job_id")
+    question_type = event.get("question_type", "general")
+    user_question = event.get("user_question", "")
+    application_id = event.get("application_id")
+    history = event.get("history", [])
+
+    logger.info(f"Processing RAG job {job_id}, question_type={question_type}")
+
     try:
-        body = json.loads(event.get("body", "{}"))
-
-        question_type = body.get("question_type", "general")
-        user_question = body.get("user_question", "")
-        application_id = body.get("application_id")
-        history = body.get("history", [])
-
-        if not user_question:
-            return {
-                "statusCode": 400,
-                "body": json.dumps({"error": "user_question is required"}),
-            }
-
-        # Get database connection
         conn = get_connection()
-        response_text = None
-
-        if question_type in ['application', 'appeal'] and not application_id:
-            return {
-                "statusCode": 400,
-                "body": json.dumps(
-                    {"error": "application_id is required for this question"}
-                ),
-            }
 
         if question_type == "application":
-            logger.info(
-                f"Processing application question for application_id={application_id}")
-
             response_text, history = answer_application_question(
                 conn, application_id, user_question, history=history
             )
-            logger.info(
-                f"Completed processing application question for application_id={application_id}")
         elif question_type == "appeal":
             response_text, history = answer_appeal_question(
                 conn, application_id, user_question, history=history
             )
         else:  # general
             response_text, history = answer_general_question(
-                user_question, history=history)
+                user_question, history=history
+            )
 
-        return {
-            "statusCode": 200,
-            "body": json.dumps({
-                "response": response_text,
-                "question_type": question_type,
-                "history": history
-            }),
-        }
+        logger.info(f"Completed RAG job {job_id}")
+        _store_job(
+            job_id,
+            "complete",
+            response=response_text,
+            history=history,
+            question_type=question_type,
+        )
 
     except Exception as e:
-        logger.error(
-            f"Error processing chatbot request: {str(e)}", exc_info=True)
-        return {
-            "statusCode": 500,
-            "body": json.dumps({"error": f"Internal server error: {str(e)}"}),
-        }
+        logger.error(f"Error processing RAG job {job_id}: {e}", exc_info=True)
+        _store_job(job_id, "error", error=str(e))
+
+
+# ==========================================
+# MAIN HANDLER — routes to the correct mode
+# ==========================================
+
+def lambda_handler(event, context):
+    """Route incoming events to the correct handler based on invocation type.
+
+    Three modes:
+      - POST /ask (API Gateway)      → _handle_dispatch
+      - GET /status/{job_id} (API GW)→ _handle_status
+      - Direct async invocation      → _process_rag_job (no return value used)
+    """
+    route_key = event.get("routeKey", "")
+
+    # No routeKey means this is a direct async self-invocation from _handle_dispatch
+    if not route_key:
+        _process_rag_job(event)
+        return
+
+    body = json.loads(event.get("body") or "{}")
+
+    if "POST /ask" in route_key:
+        return _handle_dispatch(body, context)
+
+    if "GET /status" in route_key:
+        return _handle_status(event)
+
+    return {
+        "statusCode": 404,
+        "body": json.dumps({"error": f"Unknown route: {route_key}"}),
+    }

--- a/RAG-lambda/prompt.py
+++ b/RAG-lambda/prompt.py
@@ -35,13 +35,13 @@ def generate_application_answer(client: openai.OpenAI, application_text: str, us
                     "Use the provided application text to answer the user's question."
                     "Do not attempt to answer questions outside this scope"},
                    {"role": "user", "content": f'Question: {user_question}, application url: {planning_url}, text from the application pdf: {application_text}'}]
-    print(f'history - {history}')
+
+    logging.info(f"Querying llm now with history: {history}")
+
     response = client.chat.completions.create(
         model="gpt-5-nano",
         messages=history
     )
-
-    
 
     return response.choices[0].message.content, history
 
@@ -66,8 +66,6 @@ def generate_appeal_answer(client: openai.OpenAI, application_text: str, user_qu
         messages=history
     )
 
-    
-
     return response.choices[0].message.content, history
 
 
@@ -86,5 +84,5 @@ def generate_general_answer(client: openai.OpenAI, user_question: str, history=N
         model="gpt-5-nano",
         messages=history
     )
-   
+
     return response.choices[0].message.content, history

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -10,6 +10,7 @@ with an integrated chatbot for answering questions.
 import streamlit as st
 import pandas as pd
 import os
+import logging
 
 from utils.components import (
     build_cluster_map_data,
@@ -26,6 +27,7 @@ from utils.queries import load_applications, load_council_boundaries
 from utils.chatbot import ChatbotInterface
 
 from dotenv import load_dotenv
+
 
 load_dotenv()
 # ---------------------------------------------------------------------------
@@ -73,11 +75,16 @@ def _show_search_results(filtered_df: pd.DataFrame) -> None:
 
 
 def main() -> None:
+    load_dotenv()
     """Entry point for the OpenPlan dashboard."""
     st.markdown(CSS, unsafe_allow_html=True)
 
     # Get Lambda endpoint from environment
     lambda_endpoint = os.getenv("RAG_LAMBDA_ENDPOINT", "").strip()
+
+    # For debugging - remove in production
+    print(f"Lambda endpoint: {lambda_endpoint}")
+    logging.info(f"Lambda endpoint: {lambda_endpoint}")
 
     applications = load_applications()
 

--- a/dashboard/utils/chatbot.py
+++ b/dashboard/utils/chatbot.py
@@ -63,15 +63,9 @@ class ChatbotInterface:
             lambda_endpoint: The URL of the Lambda function endpoint.
                            If None, uses mock responses for local development.
         """
-        self.lambda_endpoint = lambda_endpoint + 'ask'
+        self.lambda_endpoint = lambda_endpoint + "/ask" if lambda_endpoint else None
 
-        # Derive the status polling base URL from the /ask endpoint.
-        # e.g. https://xxx.amazonaws.com/ask  →  https://xxx.amazonaws.com/status
-        self._status_base = (
-            lambda_endpoint.rsplit("/ask", 1)[0] + "/status"
-            if lambda_endpoint
-            else None
-        )
+        self._status_base = lambda_endpoint + "/status" if lambda_endpoint else None
 
         self._initialize_session_state()
 

--- a/dashboard/utils/chatbot.py
+++ b/dashboard/utils/chatbot.py
@@ -132,8 +132,9 @@ class ChatbotInterface:
             response = requests.post(
                 self.lambda_endpoint,
                 json=payload,
-                timeout=120,
+                timeout=300,
             )
+
             response.raise_for_status()
 
             data = response.json()
@@ -142,7 +143,7 @@ class ChatbotInterface:
                 return data.get("response", "No response from server")
             else:
                 error_msg = data.get("error", "Unknown error")
-                return f"Error: {error_msg}"
+                return f"Error Calling Lambda: {error_msg}"
 
         except requests.exceptions.Timeout as e:
             logger.error(f"Lambda request timed out: {str(e)}")

--- a/dashboard/utils/chatbot.py
+++ b/dashboard/utils/chatbot.py
@@ -9,6 +9,7 @@ Communicates with a Lambda function backend for generating responses.
 import streamlit as st
 import requests
 import json
+import time
 from typing import Optional, Any
 import logging
 import numpy as np
@@ -51,6 +52,10 @@ class ChatbotInterface:
         "General Planning": "general",
     }
 
+    # Async polling: check every N seconds, give up after MAX_ATTEMPTS checks
+    POLL_INTERVAL_SECONDS: int = 3
+    POLL_MAX_ATTEMPTS: int = 100  # 100 × 3 s = 5 minutes maximum wait
+
     def __init__(self, lambda_endpoint: Optional[str] = None):
         """Initialize the chatbot interface.
 
@@ -58,7 +63,16 @@ class ChatbotInterface:
             lambda_endpoint: The URL of the Lambda function endpoint.
                            If None, uses mock responses for local development.
         """
-        self.lambda_endpoint = lambda_endpoint
+        self.lambda_endpoint = lambda_endpoint + 'ask'
+
+        # Derive the status polling base URL from the /ask endpoint.
+        # e.g. https://xxx.amazonaws.com/ask  →  https://xxx.amazonaws.com/status
+        self._status_base = (
+            lambda_endpoint.rsplit("/ask", 1)[0] + "/status"
+            if lambda_endpoint
+            else None
+        )
+
         self._initialize_session_state()
 
     def _initialize_session_state(self) -> None:
@@ -92,24 +106,80 @@ class ChatbotInterface:
             st.session_state.chatbot_question_type = new_type
             st.rerun()
 
+    def _dispatch_request(self, payload: dict) -> str:
+        """POST the question payload to /ask and return the job_id.
+
+        The Lambda dispatcher returns 202 immediately with a job_id;
+        the actual RAG work happens asynchronously on the Lambda side.
+
+        Args:
+            payload: The question payload to send to the Lambda
+
+        Returns:
+            The job_id string for use with _poll_for_result
+        """
+        response = requests.post(
+            self.lambda_endpoint,
+            json=payload,
+            timeout=30,  # 30 s is more than enough for a dispatch-only call
+        )
+        response.raise_for_status()
+        return response.json()["job_id"]
+
+    def _poll_for_result(self, job_id: str) -> str:
+        """Poll /status/{job_id} until the job completes and return the answer.
+
+        Checks every POLL_INTERVAL_SECONDS for up to POLL_MAX_ATTEMPTS attempts
+        before giving up with a timeout message.
+
+        Args:
+            job_id: The job identifier returned by _dispatch_request
+
+        Returns:
+            The response text, or an error message if the job failed / timed out
+        """
+        status_url = f"{self._status_base}/{job_id}"
+
+        for attempt in range(self.POLL_MAX_ATTEMPTS):
+            time.sleep(self.POLL_INTERVAL_SECONDS)
+
+            poll_response = requests.get(status_url, timeout=10)
+            poll_response.raise_for_status()
+            data = poll_response.json()
+
+            status = data.get("status")
+
+            if status == "complete":
+                return data.get("response", "No response from server")
+
+            if status == "error":
+                error_msg = data.get("error", "Unknown error")
+                logger.error(f"RAG job {job_id} failed: {error_msg}")
+                return f"Error processing request: {error_msg}"
+
+            logger.debug(f"Job {job_id} still pending (attempt {attempt + 1})")
+
+        return "Error: Request timed out waiting for a response. Please try again."
+
     def _get_response(
         self,
         user_question: str,
         application_id: Optional[str] = None,
     ) -> str:
-        """Get a response from the Lambda backend or mock for local development.
+        """Dispatch a question to the Lambda backend and poll for the result.
+
+        Uses an async pattern to avoid the API Gateway 29-second hard timeout:
+          1. POST to /ask  → receives a job_id immediately (202)
+          2. Poll GET /status/{job_id} until the result is ready
 
         Args:
             user_question: The user's question
             application_id: Optional application ID for specific questions
 
         Returns:
-            The response text from the Lambda function or mock response
+            The response text from the completed Lambda job
         """
         question_type = st.session_state.chatbot_question_type
-
-        # Use mock response if no endpoint is configured
-
         history = self._get_current_history()
 
         payload = {
@@ -124,40 +194,28 @@ class ChatbotInterface:
         # Convert numpy/pandas types to native Python types for JSON serialization
         payload = _convert_to_native_python(payload)
 
-        logger.info(
-            f"Sending request to Lambda endpoint: {self.lambda_endpoint}")
-        logger.debug(f"Payload: {payload}")
+        logger.info(f"Dispatching async request to: {self.lambda_endpoint}")
 
         try:
-            response = requests.post(
-                self.lambda_endpoint,
-                json=payload,
-                timeout=300,
-            )
+            job_id = self._dispatch_request(payload)
+            logger.info(f"Job dispatched, polling for result: job_id={job_id}")
+            return self._poll_for_result(job_id)
 
-            response.raise_for_status()
-
-            data = response.json()
-            logger.debug(f"Response: {data}")
-            if response.status_code == 200:
-                return data.get("response", "No response from server")
-            else:
-                error_msg = data.get("error", "Unknown error")
-                return f"Error Calling Lambda: {error_msg}"
-
+        except requests.exceptions.HTTPError as e:
+            logger.error(f"HTTP error from backend: {e}")
+            return f"Error: Backend returned {e.response.status_code}. Please try again."
         except requests.exceptions.Timeout as e:
-            logger.error(f"Lambda request timed out: {str(e)}")
+            logger.error(f"Request timed out: {e}")
             return "Error: Request timed out. Please try again."
         except requests.exceptions.ConnectionError as e:
-            logger.error(
-                f"Could not connect to Lambda endpoint ({self.lambda_endpoint}): {str(e)}")
-            return f"Error: Could not connect to backend at {self.lambda_endpoint}. Please check the endpoint is correct."
+            logger.error(f"Could not connect to {self.lambda_endpoint}: {e}")
+            return f"Error: Could not connect to backend at {self.lambda_endpoint}."
         except requests.exceptions.RequestException as e:
-            logger.error(f"Lambda request failed: {str(e)}")
-            return f"Error: {str(e)}"
+            logger.error(f"Request failed: {e}")
+            return f"Error: {e}"
         except Exception as e:
-            logger.error(f"Unexpected error: {str(e)}", exc_info=True)
-            return f"Error: {str(e)}"
+            logger.error(f"Unexpected error: {e}", exc_info=True)
+            return f"Error: {e}"
 
     def render(self, application_id: Optional[str] = None) -> None:
         """Render the chatbot interface.

--- a/dashboard/utils/db.py
+++ b/dashboard/utils/db.py
@@ -44,7 +44,7 @@ def _get_credentials() -> dict:
             "port": secret.get("port", 5432),
             "dbname": secret["dbname"],
             "user": secret["username"],
-            "password": secret["password"],
+            "password": secret["password"]
         }
     except Exception as exc:
         logging.info(
@@ -55,6 +55,7 @@ def _get_credentials() -> dict:
             "dbname": os.getenv("DB_NAME"),
             "user": os.getenv("DB_USER"),
             "password": os.getenv("DB_PASSWORD"),
+            "rag_lambda_endpoint": os.getenv("RAG_LAMBDA_ENDPOINT", "").strip(),
         }
 
 

--- a/pipeline/utilities/transform.py
+++ b/pipeline/utilities/transform.py
@@ -873,15 +873,16 @@ Return format:
                           'planning statement',
                           'consultation summary',
                           'environmental report',
-                          '	Application Form - Without Personal Data',
-                          'Correspondence',
-                          'Planning statement',
-                          'Site notice'}
+                          'application form - without personal data',
+                          'correspondence',
+                          'planning statement',
+                          'site notice'}
 
         initial_count = len(self._raw_pdfs)
 
         filtered_pdfs = [
-            pdf for pdf in self._raw_pdfs if pdf['document_type'].lower() in relevant_types]
+            pdf for pdf in self._raw_pdfs if pdf['document_type'].lower().strip() in relevant_types]
+
         final_count = len(filtered_pdfs)
 
         if initial_count > 0:

--- a/terraform/ecs-dashboard.tf
+++ b/terraform/ecs-dashboard.tf
@@ -42,6 +42,10 @@ resource "aws_ecs_task_definition" "c22-planning-dashboard" {
         {
           name  = "AWS_REGION"
           value = data.aws_region.current.name
+        },
+        {
+          name  = "RAG_LAMBDA_ENDPOINT"
+          value = "${aws_apigatewayv2_api.rag_api.api_endpoint}/ask"
         }
       ]
 

--- a/terraform/ecs-dashboard.tf
+++ b/terraform/ecs-dashboard.tf
@@ -45,7 +45,7 @@ resource "aws_ecs_task_definition" "c22-planning-dashboard" {
         },
         {
           name  = "RAG_LAMBDA_ENDPOINT"
-          value = "${aws_apigatewayv2_api.rag_api.api_endpoint}/ask"
+          value = aws_apigatewayv2_api.rag_api.api_endpoint
         }
       ]
 

--- a/terraform/rag.tf
+++ b/terraform/rag.tf
@@ -62,14 +62,62 @@ resource "aws_lambda_function" "rag_lambda" {
   environment {
     variables = {
       # Inject the plaintext values from the decoded locals
-      DB_USERNAME = local.db_secret.username
-      DB_PASSWORD = local.db_secret.password
-      LLM_API_KEY = local.llm_secret.api_key
-      DB_HOST     = aws_db_instance.pipeline-planning-db.address
-      DB_PORT     = var.rds_port
-      DB_NAME     = var.rds_database
+      DB_USERNAME    = local.db_secret.username
+      DB_PASSWORD    = local.db_secret.password
+      LLM_API_KEY    = local.llm_secret.api_key
+      DB_HOST        = aws_db_instance.pipeline-planning-db.address
+      DB_PORT        = var.rds_port
+      DB_NAME        = var.rds_database
+      # Async job tracking: table name and self-invocation function name
+      DYNAMODB_TABLE = aws_dynamodb_table.rag_jobs.name
+      FUNCTION_NAME  = "c22-planning-rag-lambda"
     }
   }
+}
+
+# ==========================================
+# 3a. DYNAMODB TABLE FOR ASYNC JOB RESULTS
+# ==========================================
+
+# Stores pending/complete/error job records so the dashboard can poll them.
+# Records are automatically expired after 1 hour via the ttl attribute.
+resource "aws_dynamodb_table" "rag_jobs" {
+  name         = "c22-planning-rag-jobs"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "job_id"
+
+  attribute {
+    name = "job_id"
+    type = "S"
+  }
+
+  ttl {
+    attribute_name = "ttl"
+    enabled        = true
+  }
+}
+
+# Grants the Lambda permission to read/write the jobs table and invoke itself.
+resource "aws_iam_role_policy" "rag_lambda_async_policy" {
+  name = "c22-planning-rag-async-policy"
+  role = aws_iam_role.rag_lambda_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["dynamodb:PutItem", "dynamodb:GetItem", "dynamodb:UpdateItem"]
+        Resource = aws_dynamodb_table.rag_jobs.arn
+      },
+      {
+        # Allows the Lambda dispatcher to invoke itself asynchronously as a worker
+        Effect   = "Allow"
+        Action   = ["lambda:InvokeFunction"]
+        Resource = aws_lambda_function.rag_lambda.arn
+      }
+    ]
+  })
 }
 
 # ==========================================
@@ -101,6 +149,13 @@ resource "aws_apigatewayv2_integration" "rag_api_integration" {
 resource "aws_apigatewayv2_route" "rag_api_route" {
   api_id    = aws_apigatewayv2_api.rag_api.id
   route_key = "POST /ask"
+  target    = "integrations/${aws_apigatewayv2_integration.rag_api_integration.id}"
+}
+
+# Polling route: dashboard calls GET /status/{job_id} to check job completion
+resource "aws_apigatewayv2_route" "rag_status_route" {
+  api_id    = aws_apigatewayv2_api.rag_api.id
+  route_key = "GET /status/{job_id}"
   target    = "integrations/${aws_apigatewayv2_integration.rag_api_integration.id}"
 }
 

--- a/terraform/rag.tf
+++ b/terraform/rag.tf
@@ -56,7 +56,7 @@ resource "aws_lambda_function" "rag_lambda" {
   package_type  = "Image"
   image_uri     = "${aws_ecr_repository.rag_lambda_repo.repository_url}:latest"
   
-  timeout       = 60 
+  timeout       = 300 
   memory_size   = 1024 
 
   environment {

--- a/terraform/rag.tf
+++ b/terraform/rag.tf
@@ -179,7 +179,7 @@ resource "aws_lambda_permission" "apigw_invoke_lambda" {
 
 output "rag_api_endpoint" {
   description = "The endpoint URL to send questions to your RAG Lambda"
-  value       = "${aws_apigatewayv2_api.rag_api.api_endpoint}/ask"
+  value       = aws_apigatewayv2_api.rag_api.api_endpoint
 }
 
 output "ecr_repository_url" {


### PR DESCRIPTION
This pull request introduces a major refactor to the Lambda chatbot backend and the Streamlit dashboard frontend to support robust asynchronous question processing, addressing API Gateway timeout limitations and improving user experience. The backend now dispatches questions as asynchronous jobs tracked in DynamoDB, while the frontend dashboard polls for completion. Additional improvements include better logging for debugging and filtering of relevant documents for RAG indexing.

**Asynchronous Job Processing (Lambda Backend):**
- Refactors `lambda_function.py` to support three modes: dispatching jobs (`POST /ask`), polling job status (`GET /status/{job_id}`), and running the actual RAG pipeline as a worker (async Lambda invocation). Job state and results are stored in DynamoDB with TTL for auto-cleanup. [[1]](diffhunk://#diff-1f2723b89499aa9a255cca46487e32a381bb8c78a624805ce759bdcf063ce8f8L3-R13) [[2]](diffhunk://#diff-1f2723b89499aa9a255cca46487e32a381bb8c78a624805ce759bdcf063ce8f8R28-R43) [[3]](diffhunk://#diff-1f2723b89499aa9a255cca46487e32a381bb8c78a624805ce759bdcf063ce8f8L104-R289) [[4]](diffhunk://#diff-1f2723b89499aa9a255cca46487e32a381bb8c78a624805ce759bdcf063ce8f8L150-R346)
- Adds helper functions for storing and retrieving job records in DynamoDB, including error handling and TTL management. [[1]](diffhunk://#diff-1f2723b89499aa9a255cca46487e32a381bb8c78a624805ce759bdcf063ce8f8R28-R43) [[2]](diffhunk://#diff-1f2723b89499aa9a255cca46487e32a381bb8c78a624805ce759bdcf063ce8f8L104-R289)

**Frontend Dashboard Integration:**
- Updates `dashboard/utils/chatbot.py` to use the new async job API: sends questions to `/ask`, then polls `/status/{job_id}` until completion, with configurable polling interval and timeout. [[1]](diffhunk://#diff-459b03d6fd54f223dfffb8dadd4904891f83624ec762de3485127b9137d5304aR55-R69) [[2]](diffhunk://#diff-459b03d6fd54f223dfffb8dadd4904891f83624ec762de3485127b9137d5304aR103-L112)
- Improves logging and endpoint configuration in `dashboard/app.py` for easier debugging and deployment. [[1]](diffhunk://#diff-ea8585cc482637297ded23c1672137835305d82aea8e223a8a8c3a9aede6e58bR13) [[2]](diffhunk://#diff-ea8585cc482637297ded23c1672137835305d82aea8e223a8a8c3a9aede6e58bR78-R88)

**Document Filtering for RAG Indexing:**
- Adds a `filter_relevant_documents` function in `extract_document_data.py` to select only relevant document types for RAG, and applies this filter in the PDF link extraction pipeline. [[1]](diffhunk://#diff-f7829e1f7bd09a36e284deee19b8dc6b72a153367dc4e166826ba18b0c5576bcR326-R354) [[2]](diffhunk://#diff-f7829e1f7bd09a36e284deee19b8dc6b72a153367dc4e166826ba18b0c5576bcL346-R384)

**Logging and Debugging Enhancements:**
- Adds detailed logging throughout the backend and frontend to trace job dispatch, status polling, and LLM queries, aiding observability and troubleshooting. [[1]](diffhunk://#diff-ba6221084b2a5348e90b93092b15fb06a019ff1b70c5a05b8cd3a4f2126f2c8dR14-R25) [[2]](diffhunk://#diff-400a5f719b4739fd0bf88fd72e05ecdc5fb4c84657716c0687faa6b0bc6b599aL38-L45) [[3]](diffhunk://#diff-ea8585cc482637297ded23c1672137835305d82aea8e223a8a8c3a9aede6e58bR13) [[4]](diffhunk://#diff-ea8585cc482637297ded23c1672137835305d82aea8e223a8a8c3a9aede6e58bR78-R88)

**Other Improvements:**
- Cleans up redundant code and improves error messages and validation for required fields in API requests. [[1]](diffhunk://#diff-1f2723b89499aa9a255cca46487e32a381bb8c78a624805ce759bdcf063ce8f8L75-R90) [[2]](diffhunk://#diff-1f2723b89499aa9a255cca46487e32a381bb8c78a624805ce759bdcf063ce8f8L150-R346)

These changes collectively enable the chatbot to reliably handle longer-running RAG jobs, provide real-time status to users, and ensure only relevant documents are indexed, all while improving maintainability and debuggability.

---

**Change references:**
- [[1]](diffhunk://#diff-1f2723b89499aa9a255cca46487e32a381bb8c78a624805ce759bdcf063ce8f8L3-R13) [[2]](diffhunk://#diff-1f2723b89499aa9a255cca46487e32a381bb8c78a624805ce759bdcf063ce8f8R28-R43) [[3]](diffhunk://#diff-1f2723b89499aa9a255cca46487e32a381bb8c78a624805ce759bdcf063ce8f8L75-R90) [[4]](diffhunk://#diff-1f2723b89499aa9a255cca46487e32a381bb8c78a624805ce759bdcf063ce8f8L104-R289) [[5]](diffhunk://#diff-1f2723b89499aa9a255cca46487e32a381bb8c78a624805ce759bdcf063ce8f8L150-R346)
- [[1]](diffhunk://#diff-459b03d6fd54f223dfffb8dadd4904891f83624ec762de3485127b9137d5304aR55-R69) [[2]](diffhunk://#diff-459b03d6fd54f223dfffb8dadd4904891f83624ec762de3485127b9137d5304aR103-L112)
- [[1]](diffhunk://#diff-ea8585cc482637297ded23c1672137835305d82aea8e223a8a8c3a9aede6e58bR13) [[2]](diffhunk://#diff-ea8585cc482637297ded23c1672137835305d82aea8e223a8a8c3a9aede6e58bR78-R88)
- [[1]](diffhunk://#diff-f7829e1f7bd09a36e284deee19b8dc6b72a153367dc4e166826ba18b0c5576bcR326-R354) [[2]](diffhunk://#diff-f7829e1f7bd09a36e284deee19b8dc6b72a153367dc4e166826ba18b0c5576bcL346-R384)
- [[1]](diffhunk://#diff-ba6221084b2a5348e90b93092b15fb06a019ff1b70c5a05b8cd3a4f2126f2c8dR14-R25) [[2]](diffhunk://#diff-400a5f719b4739fd0bf88fd72e05ecdc5fb4c84657716c0687faa6b0bc6b599aL38-L45)